### PR TITLE
[#2] Add in dashboard data flow from DB to D3 graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2247,6 +2247,273 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/d3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-6.3.0.tgz",
+      "integrity": "sha512-YILdGsjNTbvkWZKsBasB4cVDwNPnni7ILMJg9keMErQHyuII2yO2jyFdUy5E+7k/HTNP/AucrPddQuu27udbeA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "@types/d3-array": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-2.9.0.tgz",
+      "integrity": "sha512-sdBMGfNvLUkBypPMEhOcKcblTQfgHbqbYrUqRE31jOwdDHBJBxz4co2MDAq93S4Cp++phk4UiwoEg/1hK3xXAQ==",
+      "dev": true
+    },
+    "@types/d3-axis": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-2.0.0.tgz",
+      "integrity": "sha512-gUdlEwGBLl3tXGiBnBNmNzph9W3bCfa4tBgWZD60Z1eDQKTY4zyCAcZ3LksignGfKawYatmDYcBdjJ5h/54sqA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-brush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-2.1.0.tgz",
+      "integrity": "sha512-rLQqxQeXWF4ArXi81GlV8HBNwJw9EDpz0jcWvvzv548EDE4tXrayBTOHYi/8Q4FZ/Df8PGXFzxpAVQmJMjOtvQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-chord": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-2.0.0.tgz",
+      "integrity": "sha512-3nHsLY7lImpZlM/hrPeDqqW2a+lRXXoHsG54QSurDGihZAIE/doQlohs0evoHrWOJqXyn4A4xbSVEtXnMEZZiw==",
+      "dev": true
+    },
+    "@types/d3-color": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.1.tgz",
+      "integrity": "sha512-u7LTCL7RnaavFSmob2rIAJLNwu50i6gFwY9cHFr80BrQURYQBRkJ+Yv47nA3Fm7FeRhdWTiVTeqvSeOuMAOzBQ==",
+      "dev": true
+    },
+    "@types/d3-contour": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-2.0.0.tgz",
+      "integrity": "sha512-PS9UO6zBQqwHXsocbpdzZFONgK1oRUgWtjjh/iz2vM06KaXLInLiKZ9e3OLBRerc1cU2uJYpO+8zOnb6frvCGQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "@types/d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-gJYcGxLu0xDZPccbUe32OUpeaNtd1Lz0NYJtko6ZLMyG2euF4pBzrsQXms67LHZCDFzzszw+dMhSL/QAML3bXw==",
+      "dev": true
+    },
+    "@types/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-Sh0KW6z/d7uxssD7K4s4uCSzlEG/+SP+U47q098NVdOfFvUKNTvKAIV4XqjxsUuhE/854ARAREHOxkr9gQOCyg==",
+      "dev": true
+    },
+    "@types/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-VaUJPjbMnDn02tcRqsHLRAX5VjcRIzCjBfeXTLGe6QjMn5JccB5Cz4ztMRXMJfkbC45ovgJFWuj6DHvWMX1thA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-dsv": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-2.0.1.tgz",
+      "integrity": "sha512-wovgiG9Mgkr/SZ/m/c0m+RwrIT4ozsuCWeLxJyoObDWsie2DeQT4wzMdHZPR9Ya5oZLQT3w3uSl0NehG0+0dCA==",
+      "dev": true
+    },
+    "@types/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-6aZrTyX5LG+ptofVHf+gTsThLRY1nhLotJjgY4drYqk1OkJMu2UvuoZRlPw2fffjRHeYepue3/fxTufqKKmvsA==",
+      "dev": true
+    },
+    "@types/d3-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-2.0.0.tgz",
+      "integrity": "sha512-WnLepGtxepFfXRdPI8I5FTgNiHn9p4vMTTqaNCzJJfAswXx0rOY2jjeolzEU063em3iJmGZ+U79InnEeFOrCRw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "@types/d3-force": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-2.1.0.tgz",
+      "integrity": "sha512-LGDtC2YADu8OBniq9EBx/MOsXsMcJbEkmfSpXuz6oVdRamB+3CLCiq5EKFPEILGZQckkilGFq1ZTJ7kc289k+Q==",
+      "dev": true
+    },
+    "@types/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-uagdkftxnGkO4pZw5jEYOM5ZnZOEsh7z8j11Qxk85UkB2RzfUUxRl7R9VvvJZHwKn8l+x+rpS77Nusq7FkFmIg==",
+      "dev": true
+    },
+    "@types/d3-geo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-2.0.0.tgz",
+      "integrity": "sha512-DHHgYXW36lnAEQMYU2udKVOxxljHrn2EdOINeSC9jWCAXwOnGn7A19B8sNsHqgpu4F7O2bSD7//cqBXD3W0Deg==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
+    },
+    "@types/d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-YxdskUvwzqggpnSnDQj4KVkicgjpkgXn/g/9M9iGsiToLS3nG6Ytjo1FoYhYVAAElV/fJBGVL3cQ9Hb7tcv+lw==",
+      "dev": true
+    },
+    "@types/d3-interpolate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.0.tgz",
+      "integrity": "sha512-Wt1v2zTlEN8dSx8hhx6MoOhWQgTkz0Ukj7owAEIOF2QtI0e219paFX9rf/SLOr/UExWb1TcUzatU8zWwFby6gg==",
+      "dev": true,
+      "requires": {
+        "@types/d3-color": "*"
+      }
+    },
+    "@types/d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-tXcR/9OtDdeCIsyl6eTNHC3XOAOdyc6ceF3QGBXOd9jTcK+ex/ecr00p9L9362e/op3UEPpxrToi1FHrtTSj7Q==",
+      "dev": true
+    },
+    "@types/d3-polygon": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-2.0.0.tgz",
+      "integrity": "sha512-fISnMd8ePED1G4aa4V974Jmt+ajHSgPoxMa2D0ULxMybpx0Vw4WEzhQEaMIrL3hM8HVRcKTx669I+dTy/4PhAw==",
+      "dev": true
+    },
+    "@types/d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-YZuJuGBnijD0H+98xMJD4oZXgv/umPXy5deu3IimYTPGH3Kr8Th6iQUff0/6S80oNBD7KtOuIHwHUCymUiRoeQ==",
+      "dev": true
+    },
+    "@types/d3-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.0.tgz",
+      "integrity": "sha512-Hjfj9m68NmYZzushzEG7etPvKH/nj9b9s9+qtkNG3/dbRBjQZQg1XS6nRuHJcCASTjxXlyXZnKu2gDxyQIIu9A==",
+      "dev": true
+    },
+    "@types/d3-scale": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.2.2.tgz",
+      "integrity": "sha512-qpQe8G02tzUwt9sdWX1h8A/W0Q1+N48wMnYXVOkrzeLUkCfvzJYV9Ee3aORCS4dN4ONRLFmMvaXdziQ29XGLjQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-time": "*"
+      }
+    },
+    "@types/d3-scale-chromatic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-Y62+2clOwZoKua84Ha0xU77w7lePiaBoTjXugT4l8Rd5LAk+Mn/ZDtrgs087a+B5uJ3jYUHHtKw5nuEzp0WBHw==",
+      "dev": true
+    },
+    "@types/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-EF0lWZ4tg7oDFg4YQFlbOU3936e3a9UmoQ2IXlBy1+cv2c2Pv7knhKUzGlH5Hq2sF/KeDTH1amiRPey2rrLMQA==",
+      "dev": true
+    },
+    "@types/d3-shape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.0.0.tgz",
+      "integrity": "sha512-NLzD02m5PiD1KLEDjLN+MtqEcFYn4ZL9+Rqc9ZwARK1cpKZXd91zBETbe6wpBB6Ia0D0VZbpmbW3+BsGPGnCpA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-path": "^1"
+      },
+      "dependencies": {
+        "@types/d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==",
+          "dev": true
+        }
+      }
+    },
+    "@types/d3-time": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.0.0.tgz",
+      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ==",
+      "dev": true
+    },
+    "@types/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UpLg1mn/8PLyjr+J/JwdQJM/GzysMvv2CS8y+WYAL5K0+wbvXv/pPSLEfdNaprCZsGcXTxPsFMy8QtkYv9ueew==",
+      "dev": true
+    },
+    "@types/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-l6stHr1VD1BWlW6u3pxrjLtJfpPZq9I3XmKIQtq7zHM/s6fwEtI1Yn6Sr5/jQTrUDCC5jkS6gWqlFGCDArDqNg==",
+      "dev": true
+    },
+    "@types/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-UJDzI98utcZQUJt3uIit/Ho0/eBIANzrWJrTmi4+TaKIyWL2iCu7ShP0o4QajCskhyjOA7C8+4CE3b1YirTzEQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-daL0PJm4yT0ISTGa7p2lHX0kvv9FO/IR1ooWbHR/7H4jpbaKiLux5FslyS/OvISPiJ5SXb4sOqYhO6fMB6hKRw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/geojson": {
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
@@ -4972,9 +5239,9 @@
       "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
     },
     "d3-brush": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.5.tgz",
-      "integrity": "sha512-rEaJ5gHlgLxXugWjIkolTA0OyMvw8UWU1imYXy1v642XyyswmI1ybKOv05Ft+ewq+TFmdliD3VuK0pRp1VT/5A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.6.tgz",
+      "integrity": "sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==",
       "requires": {
         "d3-dispatch": "1",
         "d3-drag": "1",
@@ -5035,9 +5302,9 @@
       }
     },
     "d3-ease": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.6.tgz",
-      "integrity": "sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
     },
     "d3-fetch": {
       "version": "1.2.0",
@@ -5059,9 +5326,9 @@
       }
     },
     "d3-format": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
-      "integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "d3-geo": {
       "version": "1.12.1",
@@ -5127,9 +5394,9 @@
       }
     },
     "d3-selection": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
-      "integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
     },
     "d3-shape": {
       "version": "1.3.7",
@@ -5145,9 +5412,9 @@
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
-      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "requires": {
         "d3-time": "1"
       }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@angular/cli": "~9.1.9",
     "@angular/compiler-cli": "~9.1.11",
     "@angular/language-service": "~9.1.11",
+    "@types/d3": "^6.3.0",
     "@types/jest": "^26.0.3",
     "@types/node": "^12.11.1",
     "codelyzer": "^5.2.2",

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseAttributes.java
@@ -48,7 +48,9 @@ public class FeedbackResponseAttributes extends EntityAttributes<FeedbackRespons
 
         this.giverSection = Const.DEFAULT_SECTION;
         this.recipientSection = Const.DEFAULT_SECTION;
-        this.feedbackResponseId = FeedbackResponse.generateId(feedbackQuestionId, giver, recipient);
+        this.createdAt = Instant.now();
+        this.feedbackResponseId =
+                FeedbackResponse.generateId(feedbackQuestionId, giver, recipient, createdAt.toString());
     }
 
     public FeedbackResponseAttributes(FeedbackResponseAttributes copy) {
@@ -67,8 +69,7 @@ public class FeedbackResponseAttributes extends EntityAttributes<FeedbackRespons
 
     public static FeedbackResponseAttributes valueOf(FeedbackResponse fr) {
         FeedbackResponseAttributes fra =
-                new FeedbackResponseAttributes(
-                        fr.getFeedbackQuestionId(), fr.getGiverEmail(), fr.getRecipientEmail());
+                new FeedbackResponseAttributes(fr.getFeedbackQuestionId(), fr.getGiverEmail(), fr.getRecipientEmail());
 
         fra.feedbackResponseId = fr.getId();
         fra.feedbackSessionName = fr.getFeedbackSessionName();

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1135,7 +1135,7 @@ public class Logic {
     /**
      * Gets a list of numbers of new response submissions made in the past 12 hours under a feedback session.
      */
-    public List<Integer> getRecentResponseSubmissionStats(String courseId, String feedbackSessionName) {
+    public List<String> getRecentResponseSubmissionStats(String courseId, String feedbackSessionName) {
         Assumption.assertNotNull(courseId);
         Assumption.assertNotNull(feedbackSessionName);
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -56,7 +56,7 @@ public final class FeedbackResponsesLogic {
     /**
      * Gets a list of numbers of new response submissions made in the past 12 hours under a feedback session.
      */
-    public List<Integer> getRecentResponseSubmissionStats(String courseId, String feedbackSessionName) {
+    public List<String> getRecentResponseSubmissionStats(String courseId, String feedbackSessionName) {
         return frDb.getRecentResponseSubmissionStats(courseId, feedbackSessionName);
     }
 
@@ -84,8 +84,8 @@ public final class FeedbackResponsesLogic {
      * Gets a feedback response by its unique key.
      */
     public FeedbackResponseAttributes getFeedbackResponse(
-            String feedbackQuestionId, String giverEmail, String recipient) {
-        return frDb.getFeedbackResponse(feedbackQuestionId, giverEmail, recipient);
+            String feedbackQuestionId, String giverEmail, String recipient, String createdTime) {
+        return frDb.getFeedbackResponse(feedbackQuestionId, giverEmail, recipient, createdTime);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -3,10 +3,12 @@ package teammates.storage.api;
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +25,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
+import teammates.common.util.Logger;
 import teammates.storage.entity.FeedbackResponse;
 
 /**
@@ -32,6 +35,8 @@ import teammates.storage.entity.FeedbackResponse;
  * @see FeedbackResponseAttributes
  */
 public class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, FeedbackResponseAttributes> {
+
+    private static final Logger log = Logger.getLogger();
 
     /**
      * Gets a set of giver identifiers that has at least one response under a feedback session.
@@ -94,17 +99,17 @@ public class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, FeedbackRe
 
         List<String> res = new ArrayList<>();
         String minutePad = ":00";
-        String secondPad = ":00";
         String timePad = "0";
 
-        for (int i = 1; i <= 12; i++) {
+        for (int i = 12; i >= 1; i--) {
             String formatHour;
-            int hour = now.minus(i, ChronoUnit.HOURS).atZone(ZoneOffset.UTC).getHour();
+            int hour = now.minus(i, ChronoUnit.HOURS).atZone(ZoneId.of("Asia/Singapore")).getHour();
             if (hour < 10) {
-                formatHour = timePad + hour + minutePad + secondPad;
+                formatHour = timePad + hour + minutePad;
             } else {
-                formatHour = hour + minutePad + secondPad;
+                formatHour = hour + minutePad;
             }
+            log.info("formatHour: " + formatHour + " total :" + stats[i]);
             res.add(formatHour + "%" + stats[i]);
         }
 

--- a/src/main/java/teammates/storage/entity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponse.java
@@ -23,7 +23,7 @@ public class FeedbackResponse extends BaseEntity {
     /**
      * The unique id of the entity.
      *
-     * @see #generateId(String, String, String)
+     * @see #generateId(String, String, String, String)
      */
     @Id
     private String feedbackResponseId;
@@ -76,19 +76,19 @@ public class FeedbackResponse extends BaseEntity {
         this.receiverSection = recipientSection;
         setAnswer(answer);
 
-        this.feedbackResponseId = generateId(feedbackQuestionId, giverEmail, receiver);
-
         this.setCreatedAt(Instant.now());
+
+        this.feedbackResponseId = generateId(feedbackQuestionId, giverEmail, receiver, createdAt.toString());
     }
 
     /**
      * Generates an unique ID for the feedback response.
      */
-    public static String generateId(String feedbackQuestionId, String giver, String receiver) {
+    public static String generateId(String feedbackQuestionId, String giver, String receiver, String createdTime) {
         // Format is feedbackQuestionId%giverEmail%receiver
         // i.e. if response is feedback for team: qnId%giver@gmail.com%Team1
         //         if response is feedback for person: qnId%giver@gmail.com%reciever@email.com
-        return feedbackQuestionId + '%' + giver + '%' + receiver;
+        return feedbackQuestionId + '%' + giver + '%' + receiver + '%' + createdTime;
     }
 
     public String getId() {

--- a/src/main/java/teammates/ui/output/ResponseSubmissionStats.java
+++ b/src/main/java/teammates/ui/output/ResponseSubmissionStats.java
@@ -6,13 +6,13 @@ import java.util.List;
  * The API output format of new response submission statistics for a particular session.
  */
 public class ResponseSubmissionStats extends ApiOutput {
-    private final List<Integer> data;
+    private final List<String> data;
 
-    public ResponseSubmissionStats(List<Integer> data) {
+    public ResponseSubmissionStats(List<String> data) {
         this.data = data;
     }
 
-    public List<Integer> getData() {
+    public List<String> getData() {
         return data;
     }
 }

--- a/src/test/java/teammates/logic/api/LogicExtension.java
+++ b/src/test/java/teammates/logic/api/LogicExtension.java
@@ -19,8 +19,8 @@ public class LogicExtension extends Logic {
     }
 
     public FeedbackResponseAttributes getFeedbackResponse(
-            String feedbackQuestionId, String giverEmail, String recipient) {
-        return feedbackResponsesLogic.getFeedbackResponse(feedbackQuestionId, giverEmail, recipient);
+            String feedbackQuestionId, String giverEmail, String recipient, String createdTime) {
+        return feedbackResponsesLogic.getFeedbackResponse(feedbackQuestionId, giverEmail, recipient, createdTime);
     }
 
     public FeedbackResponseCommentAttributes getFeedbackResponseComment(

--- a/src/test/java/teammates/logic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/logic/core/CoursesLogicTest.java
@@ -561,7 +561,8 @@ public class CoursesLogicTest extends BaseLogicTest {
                 fqLogic.getFeedbackQuestion(typicalResponse.feedbackSessionName, typicalResponse.courseId,
                         Integer.parseInt(typicalResponse.feedbackQuestionId));
         typicalResponse = frLogic
-                .getFeedbackResponse(typicalQuestion.getId(), typicalResponse.giver, typicalResponse.recipient);
+                .getFeedbackResponse(typicalQuestion.getId(), typicalResponse.giver,
+                        typicalResponse.recipient, typicalResponse.getCreatedAt().toString());
         verifyPresentInDatastore(typicalResponse);
         FeedbackResponseCommentAttributes typicalComment =
                 dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1");

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -606,7 +606,8 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         FeedbackResponseAttributes fra = dataBundle.feedbackResponses.get("response1ForQ1S1C1");
         FeedbackQuestionAttributes fqa =
                 fqLogic.getFeedbackQuestion(fra.feedbackSessionName, fra.courseId, Integer.parseInt(fra.feedbackQuestionId));
-        FeedbackResponseAttributes responseInDb = frLogic.getFeedbackResponse(fqa.getId(), fra.giver, fra.recipient);
+        FeedbackResponseAttributes responseInDb
+                = frLogic.getFeedbackResponse(fqa.getId(), fra.giver, fra.recipient, fra.getCreatedAt().toString());
         assertNotNull(responseInDb);
 
         // the student only gives this response for the session

--- a/src/test/java/teammates/logic/core/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponseCommentsLogicTest.java
@@ -416,7 +416,8 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         response = frLogic.getFeedbackResponse(
                                    getQuestionIdInDataBundle(questionInDataBundle),
                                    response.giver,
-                                   response.recipient);
+                                   response.recipient,
+                                   response.getCreatedAt().toString());
         return response.getId();
     }
 }

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -126,9 +126,10 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         assertEquals(responseToUpdate.toString(),
                 frLogic.getFeedbackResponse(responseToUpdate.feedbackQuestionId, responseToUpdate.giver,
-                responseToUpdate.recipient).toString());
+                responseToUpdate.recipient, responseToUpdate.getCreatedAt().toString()).toString());
         assertNull(frLogic.getFeedbackResponse(
-                responseToUpdate.feedbackQuestionId, responseToUpdate.giver, "student2InCourse1@gmail.tmt"));
+                responseToUpdate.feedbackQuestionId, responseToUpdate.giver,
+                "student2InCourse1@gmail.tmt", responseToUpdate.getCreatedAt().toString()));
 
         ______TS("success: both giver and recipient changed (teammate changed response)");
 
@@ -137,7 +138,8 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         responseToUpdate.recipient = "Team 1.1";
 
         assertNotNull(frLogic.getFeedbackResponse(
-                responseToUpdate.feedbackQuestionId, "student4InCourse1@gmail.tmt", "Team 1.2"));
+                responseToUpdate.feedbackQuestionId,
+                "student4InCourse1@gmail.tmt", "Team 1.2", responseToUpdate.getCreatedAt().toString()));
 
         frLogic.updateFeedbackResponseCascade(
                 FeedbackResponseAttributes.updateOptionsBuilder(responseToUpdate.getId())
@@ -147,9 +149,10 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         assertEquals(responseToUpdate.toString(),
                 frLogic.getFeedbackResponse(responseToUpdate.feedbackQuestionId, responseToUpdate.giver,
-                responseToUpdate.recipient).toString());
+                responseToUpdate.recipient, responseToUpdate.getCreatedAt().toString()).toString());
         assertNull(frLogic.getFeedbackResponse(
-                responseToUpdate.feedbackQuestionId, "student4InCourse1@gmail.tmt", "Team 1.2"));
+                responseToUpdate.feedbackQuestionId, "student4InCourse1@gmail.tmt",
+                "Team 1.2", responseToUpdate.getCreatedAt().toString()));
 
         ______TS("success: update giver, recipient, giverSection and recipientSection, "
                 + "should do cascade update to comments");
@@ -824,7 +827,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         }
 
         return frLogic.getFeedbackResponse(
-                qnId, response.giver, response.recipient);
+                qnId, response.giver, response.recipient, response.getCreatedAt().toString());
     }
 
     private FeedbackResponseAttributes getResponseFromDatastore(String jsonId) {

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -807,7 +807,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         }
 
         return frLogic.getFeedbackResponse(questionId,
-                response.giver, response.recipient);
+                response.giver, response.recipient, response.getCreatedAt().toString());
     }
 
     private void unpublishAllSessions() throws InvalidParametersException, EntityDoesNotExistException {

--- a/src/test/java/teammates/logic/core/StudentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/StudentsLogicTest.java
@@ -232,7 +232,8 @@ public class StudentsLogicTest extends BaseLogicTest {
                         Integer.parseInt(responseToBeDeleted.feedbackQuestionId));
         responseToBeDeleted =
                 frLogic.getFeedbackResponse(feedbackQuestionInDb.getId(),
-                        responseToBeDeleted.giver, responseToBeDeleted.recipient);
+                        responseToBeDeleted.giver, responseToBeDeleted.recipient,
+                        responseToBeDeleted.getCreatedAt().toString());
 
         // response exist
         assertNotNull(responseToBeDeleted);
@@ -244,7 +245,8 @@ public class StudentsLogicTest extends BaseLogicTest {
 
         responseToBeDeleted =
                 frLogic.getFeedbackResponse(feedbackQuestionInDb.getId(),
-                        responseToBeDeleted.giver, responseToBeDeleted.recipient);
+                        responseToBeDeleted.giver, responseToBeDeleted.recipient,
+                        responseToBeDeleted.getCreatedAt().toString());
 
         // response should not exist
         assertNull(responseToBeDeleted);
@@ -507,7 +509,7 @@ public class StudentsLogicTest extends BaseLogicTest {
         FeedbackResponseAttributes fra = dataBundle.feedbackResponses.get("response1ForQ1S1C2");
         int qnNumber = Integer.parseInt(fra.feedbackQuestionId);
         String qnId = fqLogic.getFeedbackQuestion(fra.feedbackSessionName, fra.courseId, qnNumber).getId();
-        fra = frLogic.getFeedbackResponse(qnId, fra.giver, fra.recipient);
+        fra = frLogic.getFeedbackResponse(qnId, fra.giver, fra.recipient, fra.getCreatedAt().toString());
         assertNotNull(fra);
         // the team is the recipient of the response
         assertEquals(student2InCourse2.getTeam(), fra.recipient);

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
@@ -122,10 +122,7 @@
             <tbody>
             <tr *ngFor="let session of mapping.value; let i = index">
               <td>
-                {{ stats[mapping.key].data }}
-              </td>
-              <td>
-                <tm-session-dashboard [data]="dashboardData"></tm-session-dashboard>
+                <tm-session-dashboard [data]="stats"></tm-session-dashboard>
               </td>
             </tr>
             </tbody>

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
@@ -112,13 +112,7 @@
       </div>
       <div class="card-body session-table-body" *ngIf="institutionPanelsStatus[mapping.key]" @collapseAnim>
         <div class="table-responsive">
-          <p style="text-align: center; padding: 10px;">
-            D3 graph placeholder
-          </p>
           <table class="table table-striped data-table session-table" id="ongoing-sessions-table">
-            <thead>
-              [{{ mapping.key }}]
-            </thead>
             <tbody>
             <tr *ngFor="let session of mapping.value; let i = index">
               <td>

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
@@ -115,14 +115,18 @@
           <p style="text-align: center; padding: 10px;">
             D3 graph placeholder
           </p>
-          <!-- TODO: add D3 graph here -->
           <table class="table table-striped data-table session-table" id="ongoing-sessions-table">
             <thead>
               [{{ mapping.key }}]
             </thead>
             <tbody>
-            <tr *ngFor="let session of mapping.value">
-              <td>{{ stats[mapping.key].data }}</td>
+            <tr *ngFor="let session of mapping.value; let i = index">
+              <td>
+                {{ stats[mapping.key].data }}
+              </td>
+              <td>
+                <tm-session-dashboard [data]="dashboardData"></tm-session-dashboard>
+              </td>
             </tr>
             </tbody>
           </table>

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.html
@@ -1,7 +1,7 @@
 <h4>
   <small>
-    Below displays new feedback responses submissions made in the past 12 hours.
-    The statistics are summarised in time-series graph for ongoing sessions.
+    New feedback responses submissions made in the past 12 hours are displayed below.
+    Statistics for ongoing sessions are summarised in time-series graph.
   </small>
   <br>
 </h4>
@@ -116,7 +116,12 @@
             <tbody>
             <tr *ngFor="let session of mapping.value; let i = index">
               <td>
-                <tm-session-dashboard [data]="stats"></tm-session-dashboard>
+                <div class="session-identifier">
+                  {{ mapping.value[i].courseId + " " + mapping.value[i].feedbackSessionName }}
+                </div>
+                <div>
+                  <tm-session-dashboard [data]="stats"></tm-session-dashboard>
+                </div>
               </td>
             </tr>
             </tbody>

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.scss
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.scss
@@ -12,6 +12,11 @@
   padding: 0;
 }
 
+.session-identifier {
+  padding: 10px 0 0 15px;
+  font-weight: 600;
+}
+
 .session-table {
   margin-bottom: 0;
 }

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.spec.ts
@@ -5,6 +5,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
 import { PanelChevronModule } from '../../components/panel-chevron/panel-chevron.module';
 import { AdminDashboardPageComponent } from './admin-dashboard-page.component';
+import { SessionDashboardComponent } from './session-dashboard/session-dashboard.component';
 
 describe('AdminDashboardPageComponent', () => {
   let component: AdminDashboardPageComponent;
@@ -19,7 +20,7 @@ describe('AdminDashboardPageComponent', () => {
         LoadingSpinnerModule,
         PanelChevronModule,
       ],
-      declarations: [AdminDashboardPageComponent],
+      declarations: [AdminDashboardPageComponent, SessionDashboardComponent],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
@@ -38,6 +38,21 @@ export class AdminDashboardPageComponent implements OnInit {
   endDate: any = {};
   endTime: any = {};
 
+  dashboardData: any[] = [
+    { time: '11:00:00', total: '40' },
+    { time: '12:00:00', total: '22' },
+    { time: '13:00:00', total: '32' },
+    { time: '14:00:00', total: '25' },
+    { time: '15:00:00', total: '30' },
+    { time: '16:00:00', total: '8' },
+    { time: '17:00:00', total: '0' },
+    { time: '18:00:00', total: '0' },
+    { time: '19:00:00', total: '0' },
+    { time: '20:00:00', total: '15' },
+    { time: '21:00:00', total: '16' },
+    { time: '22:00:00', total: '17' },
+  ];
+
   isLoadingOngoingSessions: boolean = false;
 
   constructor(private timezoneService: TimezoneService,

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
@@ -38,21 +38,6 @@ export class AdminDashboardPageComponent implements OnInit {
   endDate: any = {};
   endTime: any = {};
 
-//   dashboardData: any[] = [
-//     { time: '11:00:00', total: '40' },
-//     { time: '12:00:00', total: '22' },
-//     { time: '13:00:00', total: '32' },
-//     { time: '14:00:00', total: '25' },
-//     { time: '15:00:00', total: '30' },
-//     { time: '16:00:00', total: '8' },
-//     { time: '17:00:00', total: '0' },
-//     { time: '18:00:00', total: '0' },
-//     { time: '19:00:00', total: '0' },
-//     { time: '20:00:00', total: '15' },
-//     { time: '21:00:00', total: '16' },
-//     { time: '22:00:00', total: '17' },
-//   ];
-
   isLoadingOngoingSessions: boolean = false;
 
   constructor(private timezoneService: TimezoneService,

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
@@ -24,7 +24,7 @@ export class AdminDashboardPageComponent implements OnInit {
 
   totalOngoingSessions: number = 0;
   sessions: Record<string, OngoingSession[]> = {};
-  stats: Record<string, ResponseSubmissionStats> = {};
+  stats: any[] = [];
 
   // Tracks the whether the panel of an institute has been opened
   institutionPanelsStatus: Record<string, boolean> = {};
@@ -38,20 +38,20 @@ export class AdminDashboardPageComponent implements OnInit {
   endDate: any = {};
   endTime: any = {};
 
-  dashboardData: any[] = [
-    { time: '11:00:00', total: '40' },
-    { time: '12:00:00', total: '22' },
-    { time: '13:00:00', total: '32' },
-    { time: '14:00:00', total: '25' },
-    { time: '15:00:00', total: '30' },
-    { time: '16:00:00', total: '8' },
-    { time: '17:00:00', total: '0' },
-    { time: '18:00:00', total: '0' },
-    { time: '19:00:00', total: '0' },
-    { time: '20:00:00', total: '15' },
-    { time: '21:00:00', total: '16' },
-    { time: '22:00:00', total: '17' },
-  ];
+//   dashboardData: any[] = [
+//     { time: '11:00:00', total: '40' },
+//     { time: '12:00:00', total: '22' },
+//     { time: '13:00:00', total: '32' },
+//     { time: '14:00:00', total: '25' },
+//     { time: '15:00:00', total: '30' },
+//     { time: '16:00:00', total: '8' },
+//     { time: '17:00:00', total: '0' },
+//     { time: '18:00:00', total: '0' },
+//     { time: '19:00:00', total: '0' },
+//     { time: '20:00:00', total: '15' },
+//     { time: '21:00:00', total: '16' },
+//     { time: '22:00:00', total: '17' },
+//   ];
 
   isLoadingOngoingSessions: boolean = false;
 
@@ -106,11 +106,13 @@ export class AdminDashboardPageComponent implements OnInit {
           this.totalOngoingSessions = resp.totalOngoingSessions;
           Object.keys(resp.sessions).forEach((key: string) => {
             this.sessions[key] = resp.sessions[key];
-            // TODO: retrieve response submission stats through API
             for (const fs of this.sessions[key]) {
               this.feedbackSessionsService.getRecentResponseSubmissionStats(fs.courseId, fs.feedbackSessionName)
                   .subscribe((rss: ResponseSubmissionStats) => {
-                    this.stats[key] = rss;
+                    for (const stat of rss.data) {
+                      const res: string[] = stat.split('%');
+                      this.stats.push({ time: res[0], total: res[1] });
+                    }
                   }, (error: ErrorMessageOutput) => {
                     this.statusMessageService.showErrorToast(error.error.message);
                   });

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.component.ts
@@ -29,7 +29,7 @@ export class AdminDashboardPageComponent implements OnInit {
   // Tracks the whether the panel of an institute has been opened
   institutionPanelsStatus: Record<string, boolean> = {};
 
-  showFilter: boolean = false;
+  showFilter: boolean = true;
   timezones: string[] = [];
   filterTimezone: string = '';
   tableTimezone: string = '';

--- a/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.module.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/admin-dashboard-page.module.ts
@@ -6,6 +6,7 @@ import { NgbDatepickerModule, NgbTimepickerModule } from '@ng-bootstrap/ng-boots
 import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
 import { PanelChevronModule } from '../../components/panel-chevron/panel-chevron.module';
 import { AdminDashboardPageComponent } from './admin-dashboard-page.component';
+import { SessionDashboardComponent } from './session-dashboard/session-dashboard.component';
 
 const routes: Routes = [
   {
@@ -20,9 +21,11 @@ const routes: Routes = [
 @NgModule({
   declarations: [
     AdminDashboardPageComponent,
+    SessionDashboardComponent,
   ],
   exports: [
     AdminDashboardPageComponent,
+    SessionDashboardComponent,
   ],
   imports: [
     CommonModule,

--- a/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.html
+++ b/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.html
@@ -1,0 +1,1 @@
+<svg class="bar"></svg>

--- a/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.spec.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SessionDashboardComponent } from './session-dashboard.component';
+
+describe('SessionDashboardComponent', () => {
+  let component: SessionDashboardComponent;
+  let fixture: ComponentFixture<SessionDashboardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SessionDashboardComponent],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SessionDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import * as d3 from 'd3';
 
 /**
@@ -9,7 +9,7 @@ import * as d3 from 'd3';
   templateUrl: './session-dashboard.component.html',
   styleUrls: ['./session-dashboard.component.scss'],
 })
-export class SessionDashboardComponent implements OnInit {
+export class SessionDashboardComponent implements OnInit, OnChanges {
 
   @Input() data: any[] = [];
   // @Input() barId: string = '';
@@ -21,6 +21,10 @@ export class SessionDashboardComponent implements OnInit {
   constructor() { }
 
   ngOnInit(): void {
+    this.drawBars(this.data);
+  }
+
+  ngOnChanges(): void {
     this.drawBars(this.data);
   }
 
@@ -69,22 +73,4 @@ export class SessionDashboardComponent implements OnInit {
       .attr('height', (d: any) => this.height - y(d.total))
       .attr('fill', '#d04a35');
   }
-
-//   private dataHandler(data: any) {
-//     var today = new Date();
-//     today.setHours(0, 0, 0, 0);
-//     var todayMillis = today.getTime();
-//
-//     data.forEach((d: any) => {
-//       var parts = d.time.split(/:/);
-//       var timePeriodMillis = (parseInt(parts[0], 10) * 60 * 60 * 1000) +
-//                              (parseInt(parts[1], 10) * 60 * 1000) +
-//                              (parseInt(parts[2], 10) * 1000);
-//
-//       d.time = new Date();
-//       d.time.setTime(todayMillis + timePeriodMillis);
-//     });
-//
-//     return data;
-//   }
 }

--- a/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.ts
+++ b/src/web/app/pages-admin/admin-dashboard-page/session-dashboard/session-dashboard.component.ts
@@ -1,0 +1,90 @@
+import { Component, Input, OnInit } from '@angular/core';
+import * as d3 from 'd3';
+
+/**
+ * Session D3 dashboard.
+ */
+@Component({
+  selector: 'tm-session-dashboard',
+  templateUrl: './session-dashboard.component.html',
+  styleUrls: ['./session-dashboard.component.scss'],
+})
+export class SessionDashboardComponent implements OnInit {
+
+  @Input() data: any[] = [];
+  // @Input() barId: string = '';
+
+  private margin: number = 40;
+  private width: number = 750 - (this.margin * 2);
+  private height: number = 300 - (this.margin * 2);
+
+  constructor() { }
+
+  ngOnInit(): void {
+    this.drawBars(this.data);
+  }
+
+  private drawBars(data: any[]): void {
+    let svg: any;
+
+    svg = d3.selectAll('.bar')
+      .attr('width', this.width + (this.margin * 2))
+      .attr('height', this.height + (this.margin * 2))
+      .append('g')
+      // tslint:disable-next-line
+      .attr('transform', 'translate(' + this.margin + ',' + this.margin + ')');
+
+    // Create the X-axis band scale
+    const x: any = d3.scaleBand()
+      .range([0, this.width])
+      .domain(data.map((d: any) => d.time))
+      .padding(0.2);
+
+    // Draw the X-axis on the DOM
+    svg.append('g')
+      // tslint:disable-next-line
+      .attr('transform', 'translate(0,' + this.height + ')')
+      .call(d3.axisBottom(x))
+      .selectAll('text')
+      .attr('transform', 'translate(-10,0)rotate(-45)')
+      .style('text-anchor', 'end');
+
+    // Create the Y-axis band scale
+    const y: any = d3.scaleLinear()
+      .domain([0, 100])
+      .range([this.height, 0]);
+
+    // Draw the Y-axis on the DOM
+    svg.append('g')
+    .call(d3.axisLeft(y));
+
+    // Create and fill the bars
+    svg.selectAll('bars')
+      .data(data)
+      .enter()
+      .append('rect')
+      .attr('x', (d: any) => x(d.time))
+      .attr('y', (d: any) => y(d.total))
+      .attr('width', x.bandwidth())
+      .attr('height', (d: any) => this.height - y(d.total))
+      .attr('fill', '#d04a35');
+  }
+
+//   private dataHandler(data: any) {
+//     var today = new Date();
+//     today.setHours(0, 0, 0, 0);
+//     var todayMillis = today.getTime();
+//
+//     data.forEach((d: any) => {
+//       var parts = d.time.split(/:/);
+//       var timePeriodMillis = (parseInt(parts[0], 10) * 60 * 60 * 1000) +
+//                              (parseInt(parts[1], 10) * 60 * 1000) +
+//                              (parseInt(parts[2], 10) * 1000);
+//
+//       d.time = new Date();
+//       d.time.setTime(todayMillis + timePeriodMillis);
+//     });
+//
+//     return data;
+//   }
+}


### PR DESCRIPTION
Part of #2   

**Outline of Solution**
* add basic D3 graph template
* add database query and filter logic in DB layer
* add intermediate data structure to hold data for presentation
* establish data flow to transfer query data to D3 presentation

**Discuss**
* `generateId()` needed to be re-written to include creation timestamp for keyed-only query. This function involves a lot of changes in existing attribute/action/logic interface Are there simpler walkarounds?
* It seems hard to write unique identifier for D3 graphs in admin-dashboard page with current layout design, which is needed for plotting.
* Seems better to show filter by default, since filter is necessary for the graphs to show something meaningful

**TODO**
- [ ] D3 graph unique identifier (needed to distinguish graphs in multiple <td> on the same page)
- [ ] x-axis is dependent on async data from GET request. Labels are absent on initial load
- [x] update CSS & HTML to beatify the session table in admin-dashboard-page
- [ ] real-time update is missing, still need to reload the page for updates
- [x] update failing tests due to changes in generateId() signature (low priority)

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->