### PR TITLE
Generate legacy key format consistent with the old appengine SDK

### DIFF
--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -121,7 +121,7 @@ public class FeedbackQuestion extends BaseEntity {
     }
 
     public String getId() {
-        return Key.create(FeedbackQuestion.class, feedbackQuestionId).toWebSafeString();
+        return Key.create(FeedbackQuestion.class, feedbackQuestionId).toLegacyUrlSafe();
     }
 
     public void setFeedbackQuestionId(Long feedbackQuestionId) {


### PR DESCRIPTION
**Problem:**
After Objectify migrated from v5 to v6, certain methods in the Objectify's `Key` class is deprecated, the one which concerns us is:
- `toWebSafeString` is deprecated but in order to maintain backwards compatibility with the old Objectify 5, it implements the new `toUrlSafe` method. As a result, `toWebSafeString` behaves exactly like `toUrlSafe`.
- However, the new key format with `toUrlSafe` contains the '%' character. Hence, splitting by '%' to obtain the giver and receiver no longer works. 

**Previous:**
```
agR0ZXN0chYLEhBGZWVkYmFja1F1ZXN0aW9uGAIM
%student3InCourse1@gmail.tmt%student2InCourse1@gmail.tmt
```

**Now:**
```
partition_id+%7B%0A++project_id%3A+%22test-project-b1b3a4c1-854b-45fb-9eb9-66f7e55abe9d%22%0A%7D%0Apath+%7B%0A++kind%3A+%22FeedbackQuestion%22%0A++id%3A+2%0A%7D%0A
%student3InCourse1@gmail.tmt%student2InCourse1@gmail.tmt
```

**Relevant method:**
```java
// FeedbackResponsesDb.java
public Set<String> getGiverSetThatAnswerFeedbackSession(String courseId, String feedbackSessionName) {
    Assumption.assertNotNull(courseId);
    Assumption.assertNotNull(feedbackSessionName);

    List<Key<FeedbackResponse>> keysOfResponses =
            load().filter("courseId =", courseId)
                    .filter("feedbackSessionName =", feedbackSessionName)
                    .keys()
                    .list();

    // the following process makes use of the key pattern of feedback response entity
    // see generateId() in FeedbackResponse.java
    Set<String> giverSet = new HashSet<>();
    for (Key<FeedbackResponse> key : keysOfResponses) {
        String[] tokens = key.getName().split("%");
        if (tokens.length >= 3) {
            giverSet.add(tokens[1]);
        }
    }

    return giverSet;
}
```

_Originally posted by @Derek-Hardy in https://github.com/TEAMMATES/teammates/issues/10956#issuecomment-782106397_

**Solution**
The solution is to use the `toLegacyUrlSafe` method provided by Objectify.

After considering several possible solutions, such as splitting by a different character (which would break more tests), the final solution is to maintain the legacy key format. The generated string will look something like `ag1zfnZvb2Rvb2R5bmUwcgcLEgFCGAEM` instead of  `partition_id+%7B%0A++project_id%3A+%22test-project-b1b3a4c1-854b-45fb-9eb9-66f7e55abe9d%22%0A%7D%0Apath+%7B%0A++kind%3A+%22FeedbackQuestion%22%0A++id%3A+2%0A%7D%0A...`. 

**Rationale:**
It is unlikely that the latter, lengthier string will be of any use. The legacy string suffices our purpose and is the simplest solution that makes least changes to the current codebase.